### PR TITLE
Add connectionString examples for LocalDB or MSSQL

### DIFF
--- a/GadgetsOnline/GadgetsOnline/Web.config
+++ b/GadgetsOnline/GadgetsOnline/Web.config
@@ -9,6 +9,13 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
+    <!--
+    For Amazon RDS, use:
+    <add name="GadgetsOnlineEntities" connectionString="Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;" providerName="System.Data.SqlClient" />
+
+    For LocalDB, create an App_Data folder and use:
+    <add name="GadgetsOnlineEntities" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\GadgetsOnline.mdf" providerName="System.Data.SqlClient" />
+    -->
     <add name="GadgetsOnlineEntities" connectionString="Data Source=.;Initial Catalog=GadgetsOnlineDB;Integrated Security=SSPI" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>


### PR DESCRIPTION
*Issue #, if available:*

Fix #1 

*Description of changes:*

This PR adds a commit with `connectionString` examples for using LocalDB or an external MSSQL database (ex. Amazon RDS).